### PR TITLE
Async fs

### DIFF
--- a/lib/canvas.js
+++ b/lib/canvas.js
@@ -3,7 +3,8 @@
  */
 const log = require('skog')
 const CanvasApi = require('@kth/canvas-api')
-const fs = require('fs')
+const fs = require('fs').promises
+const { createWriteStream } = require('fs')
 const path = require('path')
 const JSZip = require('jszip')
 const tempy = require('tempy')
@@ -21,18 +22,16 @@ const canvasApi = CanvasApi(
 async function sendDirectory (dir) {
   const zip = new JSZip()
   const zipFile = tempy.file({ extension: 'zip' })
-  const files = fs.readdirSync(dir)
+  const files = await fs.readdir(dir)
 
-  // TODO: don't use sync functions, use fs.readFile instead
-  // TODO: verify that zip.file is async, or don't zip the files
   for (const file of files) {
-    zip.file(file, fs.readFileSync(path.resolve(dir, file)))
+    zip.file(file, await fs.readFile(path.resolve(dir, file)))
   }
 
   await new Promise(accept => {
     zip
       .generateNodeStream({ type: 'nodebuffer', streamFiles: true })
-      .pipe(fs.createWriteStream(zipFile))
+      .pipe(createWriteStream(zipFile))
       .on('finish', function () {
         log.info(`Finished generating zip file "${zipFile}"`)
         accept()


### PR DESCRIPTION
This PR uses `fs.promises` instead of `fs` whenever possible