### PR TITLE
Get examiners from AKT-api instead of Kopps

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,29 +5,11 @@ const fs = require('fs')
 const csv = require('fast-csv')
 const tempy = require('tempy')
 const { sendDirectory } = require('./canvas')
-const memoizee = require('memoizee')
 
 const BLUEPRINT_SIS_ID = process.env.BLUEPRINT_SIS_ID
 const EXAMINER_ROLE_ID = 10
 const STUDENT_ROLE_ID = 3
 
-/** Get examinators from Kopps */
-async function getExaminers (courseCode) {
-  try {
-    const { body } = await got(
-      // TODO: Make this to work even if the "KOPPS_API_URL" has a trailing slash
-      `${process.env.KOPPS_API_URL}/course/${courseCode}/detailedinformation`,
-      {
-        responseType: 'json'
-      }
-    )
-
-    return body.examiners
-  } catch (err) {
-    log.error(err, `Error calling kopps api for course code ${courseCode}`)
-    return []
-  }
-}
 
 /** Get the "Kontrolskrivning" activities of a day from AKT_API */
 async function getActivities (date) {
@@ -149,21 +131,16 @@ async function writeCoursesAndSections (activities, coursesFile, sectionsFile) {
 }
 
 async function writeExaminers (activities, file) {
-  const getExaminersMemo = memoizee(getExaminers)
-
   // TODO: rename this to normalizedActivities
   const normalized = []
 
   for (const activity of activities) {
-    // FYI: I tried using reduce here instead, which ended up with the much worse line:
-    // const courseCodes = activity.aktiviteter.reduce((accumulator, currentValue) => {accumulator.push(...currentValue.courseCodes); return accumulator}, [])
-    // I def prefer your code over mine :)
-    const courseCodes = []
-    activity.aktiviteter.forEach(akt => courseCodes.push(...akt.courseCodes))
-
     const examiners = []
-    for (const courseCode of courseCodes) {
-      examiners.push(...(await getExaminersMemo(courseCode)))
+
+    for (const akt of activity.aktiviteter) {
+      for (const examiner of akt.courseExaminers) {
+        examiners.push(examiner)
+      }
     }
 
     log.info(


### PR DESCRIPTION
This PR uses the "aktivitetstillfälle API" instead of "Kopps" for getting the examiners for activities