### PR TITLE
Fix constant time

### DIFF
--- a/cron/index.js
+++ b/cron/index.js
@@ -9,11 +9,6 @@ const INTERVAL = process.env.INTERVAL || '0 5 * * *'
 // "0,30 * * * *" = "Every 30 minutes (at X:00 and X:30)"
 const FAILURE_INTERVAL = '0,30 * * * *'
 
-const numberOfDays = 30
-const startDate = new Date()
-const endDate = new Date()
-endDate.setDate(startDate.getDate() + numberOfDays)
-
 let job
 let running = false
 
@@ -26,6 +21,11 @@ async function sync () {
   }
 
   running = true
+
+  const numberOfDays = 30
+  const startDate = new Date()
+  const endDate = new Date()
+  endDate.setDate(startDate.getDate() + numberOfDays)
 
   await log.child({ req_id: cuid() }, async () => {
     log.info(`Starting sync for period ${startDate} to ${endDate}`)

--- a/server/index.js
+++ b/server/index.js
@@ -26,7 +26,7 @@ app.get(prefix + '/_monitor_all', async (req, res) => {
       '',
       '- NEXT INVOCATION:',
       `  <script>document.write(new Date(${cron.nextSync().getTime()}))</script> (local time in your computer)`,
-      `- SYNC IS RUNNING NOW: ${cron.isRunning ? 'YES' : 'NO'}`,
+      `- SYNC IS RUNNING NOW: ${cron.isRunning() ? 'YES' : 'NO'}`,
       '',
       'Environment:',
       `- CANVAS_API_URL: ${process.env.CANVAS_API_URL}`,


### PR DESCRIPTION
This PR fixes a bug in which `startDate` and `endDate` were global variables instead of being relative to the date when the function is run.