### PR TITLE
Send files with "lms-activity-rooms" prefix

### DIFF
--- a/lib/canvas.js
+++ b/lib/canvas.js
@@ -31,7 +31,7 @@ async function test () {
 async function sendDirectory (dir) {
   try {
     const zip = new JSZip()
-    const zipFile = path.join(dir, `lms-activity-rooms.${(new Date()).toISOString()}.zip`)
+    const zipFile = path.join(dir, 'lms-activity-rooms.zip')
     const files = await fs.readdir(dir)
 
     for (const file of files) {

--- a/lib/canvas.js
+++ b/lib/canvas.js
@@ -31,7 +31,7 @@ async function test () {
 async function sendDirectory (dir) {
   try {
     const zip = new JSZip()
-    const zipFile = path.join(dir, 'enrollments.zip')
+    const zipFile = path.join(dir, `lms-activity-rooms.${(new Date()).toISOString()}.zip`)
     const files = await fs.readdir(dir)
 
     for (const file of files) {
@@ -59,25 +59,6 @@ async function sendDirectory (dir) {
     log.info(
       `SIS IMPORT: correctly created with ID [${response.id}]. Details: ${url}`
     )
-
-    let progress = 0
-    let sisImport = null
-
-    while (progress < 100) {
-      sisImport = (
-        await canvasApi.get(`/accounts/1/sis_imports/${response.id}`)
-      ).body
-      progress = sisImport.progress
-      log.trace(
-        `SIS IMPORT [${response.id}] status "${sisImport.workflow_state}". Progress: ${progress}`
-      )
-    }
-
-    if (sisImport.workflow_state !== 'imported') {
-      log.error(`SIS IMPORT ERROR. Please check ${url}`)
-    } else {
-      log.info(`SIS IMPORT CORRECTLY FINISHED. Details: ${url}`)
-    }
   } catch (err) {
     log.error(err)
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -260,11 +260,17 @@ async function writeActivities (start, end, dir) {
 
   await writeCoursesAndSections(
     activities,
-    path.resolve(dir, 'courses.csv'),
-    path.resolve(dir, 'sections.csv')
+    path.resolve(dir, 'lms-activity-rooms.courses.csv'),
+    path.resolve(dir, 'lms-activity-rooms.sections.csv')
   )
-  await writeExaminers(activities, path.resolve(dir, 'examiners.csv'))
-  await writeStudents(activities, path.resolve(dir, 'students.csv'))
+  await writeExaminers(
+    activities,
+    path.resolve(dir, 'lms-activity-rooms.examiners.csv')
+  )
+  await writeStudents(
+    activities,
+    path.resolve(dir, 'lms-activity-rooms.students.csv')
+  )
 }
 
 /** Sends all activities of a certain period of time to Canvas */


### PR DESCRIPTION
This PR:

- Removes the logic that "waits for the SIS Import to be processed by Canvas" which avoids hanging
- Sends the file with a `lms-activity-rooms` prefix so it can be monitored by LMS SIS Monitor. See https://github.com/KTH/lms-sis-monitor/pull/8 for details